### PR TITLE
libvterm: unmask the package

### DIFF
--- a/metadata/repository_mask.conf
+++ b/metadata/repository_mask.conf
@@ -1,6 +1,5 @@
 (
     media-libs/openFrameworks[~scm]
-    x11-libs/libvterm[~scm]
     x11-misc/lemonbar[~scm]
 ) [[
     *author = [ Jonathan Dahan ]


### PR DESCRIPTION
Unmask the package as libvterm is needed by neovim and scm is the only
version available.