### PR TITLE
libvterm: bump to 0.1.2, switch scm to nvim branch

### DIFF
--- a/packages/x11-libs/libvterm/libvterm-0.0_p20181011.exheres-0
+++ b/packages/x11-libs/libvterm/libvterm-0.0_p20181011.exheres-0
@@ -1,9 +1,0 @@
-# Copyright 2015 Jonathan Dahan <jonathan@jonathan.is>
-# Distributed under the terms of the GNU General Public License v2
-
-GITHUB_TAG=0c4f9b847822a4f07c382596def5dcb3180b5659
-
-require libvterm
-
-PLATFORMS="~amd64"
-

--- a/packages/x11-libs/libvterm/libvterm-0.1.2.exheres-0
+++ b/packages/x11-libs/libvterm/libvterm-0.1.2.exheres-0
@@ -1,0 +1,12 @@
+# Copyright 2015 Jonathan Dahan <jonathan@jonathan.is>
+# Distributed under the terms of the GNU General Public License v2
+
+# Unfortunately, github repo does not have any release tags.
+# SHA1 points to the "version bump" commit, matches neovim bundled version:
+# https://github.com/neovim/neovim/blob/v0.4.3/third-party/CMakeLists.txt#L163
+GITHUB_TAG=7c72294d84ce20da4c27362dbd7fa4b08cfc91da
+
+require libvterm
+
+PLATFORMS="~amd64"
+

--- a/packages/x11-libs/libvterm/libvterm-scm.exheres-0
+++ b/packages/x11-libs/libvterm/libvterm-scm.exheres-0
@@ -1,6 +1,11 @@
 # Copyright 2015 Jonathan Dahan <jonathan@jonathan.is>
 # Distributed under the terms of the GNU General Public License v2
 
+# 'nvim' is the default development branch.
+# master may contain incompatible changes and should never be used:
+# https://github.com/neovim/neovim/pull/11687
+GITHUB_BRANCH=nvim
+
 require libvterm
 
 PLATFORMS="~amd64"


### PR DESCRIPTION
Preparation for neovim-0.4.3 version bump.

Note: libvterm-0.1.2 is not compatible with neovim-0.3.7:

    *** stack smashing detected ***: terminated
    Aborted (core dumped)

This needs to be merged in sync with https://gitlab.exherbo.org/medvid/medvid/merge_requests/29